### PR TITLE
ルーティング設定の追加とテストページの作成

### DIFF
--- a/lib/pages/all_shift_page.dart
+++ b/lib/pages/all_shift_page.dart
@@ -1,0 +1,171 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class AllShiftPage extends StatefulWidget {
+  @override
+  _AllShiftPageState createState() => _AllShiftPageState();
+}
+
+class _AllShiftPageState extends State<AllShiftPage> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('全体シフト'),
+        actions: <Widget>[],
+        // debug
+      ),
+      drawer: Drawer(
+          child: ListView(
+        children: <Widget>[
+          ListTile(
+            title: Text("マイシフト"),
+            leading: const Icon(Icons.dvr),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/my_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("全体シフト"),
+            leading: Icon(Icons.dynamic_feed),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/all_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("マニュアル一覧"),
+            leading: Icon(Icons.list_alt),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/manual_list_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("タイムスケジュール"),
+            leading: Icon(Icons.schedule),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/schedule_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("本部連絡先"),
+            leading: Icon(Icons.contact_phone),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/contact_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("再ログイン"),
+            leading: Icon(Icons.login),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/', (Route<dynamic> route) => false)
+            },
+          ),
+        ],
+      )),
+      body: FutureBuilder(
+        future: getData(),
+        builder: (ctx, snapshot) {
+          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
+            logger.w("message");
+          }
+          if (!snapshot.hasData) {
+            return CircularProgressIndicator();
+          }
+          return Container(
+              padding: const EdgeInsets.all(40.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                        // height: size.height - 200,
+                        // width: size.width - 80,
+                        // padding: const EdgeInsets.all(10.0),
+                        // decoration: BoxDecoration(
+                        //   border: Border.all(color: Colors.black),
+                        // ),
+                        // child: _contents(size, snapshot.data)),
+                        child: _table(snapshot.data)),
+                  ],
+                ),
+              ));
+        },
+      ),
+    );
+  }
+}
+
+Widget _table(var shifts) {
+  return Table(
+      border: TableBorder.all(color: Colors.black),
+      columnWidths: const <int, TableColumnWidth>{
+        // 0: IntrinsicColumnWidth(),
+        0: FlexColumnWidth(1),
+        1: FlexColumnWidth(10),
+        // 2: FixedColumnWidth(100.0),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        TableRow(children: [
+          TableCell(
+              child: Container(
+            child: Text("日時"),
+            alignment: Alignment.center,
+            color: Colors.lightGreen,
+          )),
+          TableCell(
+            child: Container(
+              child: Text("場所"),
+              alignment: Alignment.center,
+              color: Colors.lightGreen,
+            ),
+          )
+        ]),
+        for (var shift in shifts)
+          TableRow(
+              decoration: BoxDecoration(color: Colors.grey[200]),
+              children: [
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Time"].toString()),
+                )),
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Work"].toString()),
+                  // margin: EdgeInsets.only(bottom: 10.0),
+                  height: 25,
+                ))
+              ]),
+      ]);
+}
+
+Future getData() async {
+  try {
+    var userID = await store.getUserID();
+    var res = await api.getMyShift(userID.toString());
+    return res;
+  } catch (err) {
+    logger.e('don`t response. error message: $err');
+  }
+}

--- a/lib/pages/contact_page.dart
+++ b/lib/pages/contact_page.dart
@@ -1,0 +1,171 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class ContactPage extends StatefulWidget {
+  @override
+  _ContactPageState createState() => _ContactPageState();
+}
+
+class _ContactPageState extends State<ContactPage> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('本部連絡先'),
+        actions: <Widget>[],
+        // debug
+      ),
+      drawer: Drawer(
+          child: ListView(
+        children: <Widget>[
+          ListTile(
+            title: Text("マイシフト"),
+            leading: const Icon(Icons.dvr),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/my_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("全体シフト"),
+            leading: Icon(Icons.dynamic_feed),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/all_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("マニュアル一覧"),
+            leading: Icon(Icons.list_alt),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/manual_list_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("タイムスケジュール"),
+            leading: Icon(Icons.schedule),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/schedule_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("本部連絡先"),
+            leading: Icon(Icons.contact_phone),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/contact_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("再ログイン"),
+            leading: Icon(Icons.login),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/', (Route<dynamic> route) => false)
+            },
+          ),
+        ],
+      )),
+      body: FutureBuilder(
+        future: getData(),
+        builder: (ctx, snapshot) {
+          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
+            logger.w("message");
+          }
+          if (!snapshot.hasData) {
+            return CircularProgressIndicator();
+          }
+          return Container(
+              padding: const EdgeInsets.all(40.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                        // height: size.height - 200,
+                        // width: size.width - 80,
+                        // padding: const EdgeInsets.all(10.0),
+                        // decoration: BoxDecoration(
+                        //   border: Border.all(color: Colors.black),
+                        // ),
+                        // child: _contents(size, snapshot.data)),
+                        child: _table(snapshot.data)),
+                  ],
+                ),
+              ));
+        },
+      ),
+    );
+  }
+}
+
+Widget _table(var shifts) {
+  return Table(
+      border: TableBorder.all(color: Colors.black),
+      columnWidths: const <int, TableColumnWidth>{
+        // 0: IntrinsicColumnWidth(),
+        0: FlexColumnWidth(1),
+        1: FlexColumnWidth(10),
+        // 2: FixedColumnWidth(100.0),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        TableRow(children: [
+          TableCell(
+              child: Container(
+            child: Text("日時"),
+            alignment: Alignment.center,
+            color: Colors.lightGreen,
+          )),
+          TableCell(
+            child: Container(
+              child: Text("場所"),
+              alignment: Alignment.center,
+              color: Colors.lightGreen,
+            ),
+          )
+        ]),
+        for (var shift in shifts)
+          TableRow(
+              decoration: BoxDecoration(color: Colors.grey[200]),
+              children: [
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Time"].toString()),
+                )),
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Work"].toString()),
+                  // margin: EdgeInsets.only(bottom: 10.0),
+                  height: 25,
+                ))
+              ]),
+      ]);
+}
+
+Future getData() async {
+  try {
+    var userID = await store.getUserID();
+    var res = await api.getMyShift(userID.toString());
+    return res;
+  } catch (err) {
+    logger.e('don`t response. error message: $err');
+  }
+}

--- a/lib/pages/manual_list_page.dart
+++ b/lib/pages/manual_list_page.dart
@@ -1,0 +1,171 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class ManualListPage extends StatefulWidget {
+  @override
+  _ManualListPageState createState() => _ManualListPageState();
+}
+
+class _ManualListPageState extends State<ManualListPage> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('マニュアル一覧'),
+        actions: <Widget>[],
+        // debug
+      ),
+      drawer: Drawer(
+          child: ListView(
+        children: <Widget>[
+          ListTile(
+            title: Text("マイシフト"),
+            leading: const Icon(Icons.dvr),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/my_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("全体シフト"),
+            leading: Icon(Icons.dynamic_feed),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/all_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("マニュアル一覧"),
+            leading: Icon(Icons.list_alt),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/manual_list_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("タイムスケジュール"),
+            leading: Icon(Icons.schedule),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/schedule_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("本部連絡先"),
+            leading: Icon(Icons.contact_phone),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/contact_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("再ログイン"),
+            leading: Icon(Icons.login),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/', (Route<dynamic> route) => false)
+            },
+          ),
+        ],
+      )),
+      body: FutureBuilder(
+        future: getData(),
+        builder: (ctx, snapshot) {
+          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
+            logger.w("message");
+          }
+          if (!snapshot.hasData) {
+            return CircularProgressIndicator();
+          }
+          return Container(
+              padding: const EdgeInsets.all(40.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                        // height: size.height - 200,
+                        // width: size.width - 80,
+                        // padding: const EdgeInsets.all(10.0),
+                        // decoration: BoxDecoration(
+                        //   border: Border.all(color: Colors.black),
+                        // ),
+                        // child: _contents(size, snapshot.data)),
+                        child: _table(snapshot.data)),
+                  ],
+                ),
+              ));
+        },
+      ),
+    );
+  }
+}
+
+Widget _table(var shifts) {
+  return Table(
+      border: TableBorder.all(color: Colors.black),
+      columnWidths: const <int, TableColumnWidth>{
+        // 0: IntrinsicColumnWidth(),
+        0: FlexColumnWidth(1),
+        1: FlexColumnWidth(10),
+        // 2: FixedColumnWidth(100.0),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        TableRow(children: [
+          TableCell(
+              child: Container(
+            child: Text("日時"),
+            alignment: Alignment.center,
+            color: Colors.lightGreen,
+          )),
+          TableCell(
+            child: Container(
+              child: Text("場所"),
+              alignment: Alignment.center,
+              color: Colors.lightGreen,
+            ),
+          )
+        ]),
+        for (var shift in shifts)
+          TableRow(
+              decoration: BoxDecoration(color: Colors.grey[200]),
+              children: [
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Time"].toString()),
+                )),
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Work"].toString()),
+                  // margin: EdgeInsets.only(bottom: 10.0),
+                  height: 25,
+                ))
+              ]),
+      ]);
+}
+
+Future getData() async {
+  try {
+    var userID = await store.getUserID();
+    var res = await api.getMyShift(userID.toString());
+    return res;
+  } catch (err) {
+    logger.e('don`t response. error message: $err');
+  }
+}

--- a/lib/pages/my_shift_page.dart
+++ b/lib/pages/my_shift_page.dart
@@ -29,7 +29,9 @@ class _MyShiftPageState extends State<MyShiftPage> {
         actions: <Widget>[],
         // debug
       ),
-      drawer: Drawer(
+      drawer: drawer.applicationDrawer(context),
+      /*
+      Drawer(
           child: ListView(
         children: <Widget>[
           ListTile(
@@ -82,6 +84,7 @@ class _MyShiftPageState extends State<MyShiftPage> {
           ),
         ],
       )),
+      */
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {

--- a/lib/pages/my_shift_page.dart
+++ b/lib/pages/my_shift_page.dart
@@ -35,27 +35,42 @@ class _MyShiftPageState extends State<MyShiftPage> {
           ListTile(
             title: Text("マイシフト"),
             leading: const Icon(Icons.dvr),
-            onTap: () => {},
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/my_shift_page', (Route<dynamic> route) => false)
+            },
           ),
           ListTile(
             title: Text("全体シフト"),
             leading: Icon(Icons.dynamic_feed),
-            onTap: () => {},
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/all_shift_page', (Route<dynamic> route) => false)
+            },
           ),
           ListTile(
             title: Text("マニュアル一覧"),
             leading: Icon(Icons.list_alt),
-            onTap: () => {},
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/manual_list_page', (Route<dynamic> route) => false)
+            },
           ),
           ListTile(
             title: Text("タイムスケジュール"),
             leading: Icon(Icons.schedule),
-            onTap: () => {},
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/schedule_page', (Route<dynamic> route) => false)
+            },
           ),
           ListTile(
             title: Text("本部連絡先"),
             leading: Icon(Icons.contact_phone),
-            onTap: () => {},
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/contact_page', (Route<dynamic> route) => false)
+            },
           ),
           ListTile(
             title: Text("再ログイン"),

--- a/lib/pages/schedule_page.dart
+++ b/lib/pages/schedule_page.dart
@@ -1,0 +1,171 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class SchedulePage extends StatefulWidget {
+  @override
+  _SchedulePageState createState() => _SchedulePageState();
+}
+
+class _SchedulePageState extends State<SchedulePage> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('タイムスケジュール'),
+        actions: <Widget>[],
+        // debug
+      ),
+      drawer: Drawer(
+          child: ListView(
+        children: <Widget>[
+          ListTile(
+            title: Text("マイシフト"),
+            leading: const Icon(Icons.dvr),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/my_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("全体シフト"),
+            leading: Icon(Icons.dynamic_feed),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/all_shift_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("マニュアル一覧"),
+            leading: Icon(Icons.list_alt),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/manual_list_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("タイムスケジュール"),
+            leading: Icon(Icons.schedule),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/schedule_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("本部連絡先"),
+            leading: Icon(Icons.contact_phone),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/contact_page', (Route<dynamic> route) => false)
+            },
+          ),
+          ListTile(
+            title: Text("再ログイン"),
+            leading: Icon(Icons.login),
+            onTap: () => {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/', (Route<dynamic> route) => false)
+            },
+          ),
+        ],
+      )),
+      body: FutureBuilder(
+        future: getData(),
+        builder: (ctx, snapshot) {
+          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
+            logger.w("message");
+          }
+          if (!snapshot.hasData) {
+            return CircularProgressIndicator();
+          }
+          return Container(
+              padding: const EdgeInsets.all(40.0),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                        // height: size.height - 200,
+                        // width: size.width - 80,
+                        // padding: const EdgeInsets.all(10.0),
+                        // decoration: BoxDecoration(
+                        //   border: Border.all(color: Colors.black),
+                        // ),
+                        // child: _contents(size, snapshot.data)),
+                        child: _table(snapshot.data)),
+                  ],
+                ),
+              ));
+        },
+      ),
+    );
+  }
+}
+
+Widget _table(var shifts) {
+  return Table(
+      border: TableBorder.all(color: Colors.black),
+      columnWidths: const <int, TableColumnWidth>{
+        // 0: IntrinsicColumnWidth(),
+        0: FlexColumnWidth(1),
+        1: FlexColumnWidth(10),
+        // 2: FixedColumnWidth(100.0),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        TableRow(children: [
+          TableCell(
+              child: Container(
+            child: Text("日時"),
+            alignment: Alignment.center,
+            color: Colors.lightGreen,
+          )),
+          TableCell(
+            child: Container(
+              child: Text("場所"),
+              alignment: Alignment.center,
+              color: Colors.lightGreen,
+            ),
+          )
+        ]),
+        for (var shift in shifts)
+          TableRow(
+              decoration: BoxDecoration(color: Colors.grey[200]),
+              children: [
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Time"].toString()),
+                )),
+                TableCell(
+                    child: Container(
+                  alignment: Alignment.center,
+                  child: new Text(shift["Work"].toString()),
+                  // margin: EdgeInsets.only(bottom: 10.0),
+                  height: 25,
+                ))
+              ]),
+      ]);
+}
+
+Future getData() async {
+  try {
+    var userID = await store.getUserID();
+    var res = await api.getMyShift(userID.toString());
+    return res;
+  } catch (err) {
+    logger.e('don`t response. error message: $err');
+  }
+}

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -69,7 +69,7 @@ class Api {
     }
   }
 
-  // POST Sign In
+  // POST Sign In (リダイレクションエラーが返ってくるため不使用)
   Future postSignIn(request) async {
     var url = Uri.parse(constant.apiUrl + 'auth');
     var response = await http.post(url,
@@ -84,6 +84,7 @@ class Api {
     }
   }
 
+  // Get Sign In
   Future signIn(mail) async {
     try {
       var url = constant.apiUrl + "auth/" + mail;

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -1,0 +1,61 @@
+import 'package:seeft_mobile/configs/importer.dart';
+
+final ApplicationDrawer drawer = ApplicationDrawer();
+
+class ApplicationDrawer {
+  Widget applicationDrawer(context) {
+    return Drawer(
+        child: ListView(
+      children: <Widget>[
+        ListTile(
+          title: Text("マイシフト"),
+          leading: const Icon(Icons.dvr),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/my_shift_page', (Route<dynamic> route) => false)
+          },
+        ),
+        ListTile(
+          title: Text("全体シフト"),
+          leading: Icon(Icons.dynamic_feed),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/all_shift_page', (Route<dynamic> route) => false)
+          },
+        ),
+        ListTile(
+          title: Text("マニュアル一覧"),
+          leading: Icon(Icons.list_alt),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/manual_list_page', (Route<dynamic> route) => false)
+          },
+        ),
+        ListTile(
+          title: Text("タイムスケジュール"),
+          leading: Icon(Icons.schedule),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/schedule_page', (Route<dynamic> route) => false)
+          },
+        ),
+        ListTile(
+          title: Text("本部連絡先"),
+          leading: Icon(Icons.contact_phone),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/contact_page', (Route<dynamic> route) => false)
+          },
+        ),
+        ListTile(
+          title: Text("再ログイン"),
+          leading: Icon(Icons.login),
+          onTap: () => {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/', (Route<dynamic> route) => false)
+          },
+        ),
+      ],
+    ));
+  }
+}

--- a/lib/widgets/first_jump_selector.dart
+++ b/lib/widgets/first_jump_selector.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:seeft_mobile/configs/importer.dart';
-import 'package:seeft_mobile/pages/my_shift_page.dart';
 import 'package:seeft_mobile/pages/sign_in_page.dart';
+import 'package:seeft_mobile/pages/my_shift_page.dart';
+import 'package:seeft_mobile/pages/all_shift_page.dart';
+import 'package:seeft_mobile/pages/manual_list_page.dart';
+import 'package:seeft_mobile/pages/schedule_page.dart';
+import 'package:seeft_mobile/pages/contact_page.dart';
 
 class FirstJumpSelector extends StatefulWidget {
   @override
@@ -65,6 +69,10 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
           routes: {
             '/': (context) => SignInPage(),
             '/my_shift_page': (context) => MyShiftPage(),
+            '/all_shift_page': (context) => AllShiftPage(),
+            '/manual_list_page': (context) => ManualListPage(),
+            '/schedule_page': (context) => SchedulePage(),
+            '/contact_page': (context) => ContactPage(),
           },
         );
 


### PR DESCRIPTION
resolved #5 

# 概要
`first_jump_selector.dart`にルーティングの設定を追加
ルーティング先の全体シフト，マニュアル一覧，タイムスケジュール，本部連絡先のテストページを作成

# スクリーンショット
![image](https://user-images.githubusercontent.com/66663224/134800386-fa189835-1f69-496b-b563-23e326852657.png)
