### PR TITLE
[fix]create all manual page & fix table width(#8)

### DIFF
--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -153,6 +153,18 @@ class Api {
     }
   }
 
+  // マニュアル一覧
+  Future getAllManual() async {
+    String url = constant.apiUrl + 'work/list';
+    try {
+      return await get(url);
+    } catch (err) {
+      logger.e(err);
+      // calling api.get みたいに呼び出し元参照できるようにしたい
+      throw err;
+    }
+  }
+
   // POST Sign In (リダイレクションエラーが返ってくるため不使用)
   Future postSignIn(request) async {
     var url = Uri.parse(constant.apiUrl + 'auth');

--- a/lib/widgets/table.dart
+++ b/lib/widgets/table.dart
@@ -9,7 +9,7 @@ class ShiftTable {
         columnWidths: const <int, TableColumnWidth>{
           // 0: IntrinsicColumnWidth(),
           0: FlexColumnWidth(1),
-          1: FlexColumnWidth(7),
+          1: FlexColumnWidth(3),
           // 2: FixedColumnWidth(100.0),
         },
         defaultVerticalAlignment: TableCellVerticalAlignment.middle,


### PR DESCRIPTION
- サイドバーからマニュアル一覧を選択した際にマニュアル一覧ページを表示できるようにした
  - 名前の部分をタップするとマニュアルのページに遷移する（今はgoogle.comに遷移）
  - スクロール可能
- My shiftのカラムの幅を調節した

![image](https://user-images.githubusercontent.com/71711872/135271401-b0acff87-98d9-4262-b470-ef14f2668c74.png)
![image](https://user-images.githubusercontent.com/71711872/135272039-a04f76d8-6efa-4e17-8ba9-b3115476585f.png)

