### PR TITLE
シフトの背景色を設定

### DIFF
--- a/lib/widgets/table.dart
+++ b/lib/widgets/table.dart
@@ -57,18 +57,18 @@ class ShiftTable {
                     height: 25,
                     */
                       child: Container(
+                    //color: HexColor(shifts[index]["Color"].toString()),
                     width: double.infinity,
+                    height: 40,
+                    //color: HexColor(shifts[index]["Color"].toString()),
                     padding: EdgeInsets.all(0),
                     //height: 25.0,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(50),
-                    ),
-                    child: TextButton(
-                        child: new Text(shifts[index]["Work"].toString()),
-                        style: ElevatedButton.styleFrom(onPrimary: Colors.amber
-                            //HexColor(shifts[index]["Color"].toString()),
-                            ),
-                        onPressed: () async {
+                    child: new Material(
+                      type: MaterialType.button,
+                      color: HexColor(shifts[index]["Color"]),
+                      child: InkWell(
+                        splashColor: Colors.orangeAccent,
+                        onTap: () async {
                           if (shifts[index]["Work"] != "") {
                             logger.i(shifts[index]["Work"]);
                             await openShiftDialog(
@@ -79,7 +79,15 @@ class ShiftTable {
                                 shifts[index]["Weather"],
                                 shifts[index]["Time"]);
                           }
-                        }),
+                        },
+                        //child: Center(child: new Text(shifts[index]["Work"].toString())),
+                        child: Container(
+                          child: Center(
+                              child:
+                                  new Text(shifts[index]["Work"].toString())),
+                        ),
+                      ),
+                    ),
                   ))
                 ]),
         ]);

--- a/lib/widgets/table.dart
+++ b/lib/widgets/table.dart
@@ -5,7 +5,7 @@ final ShiftTable table = ShiftTable();
 class ShiftTable {
   Widget shiftTable(var shifts, context) {
     return Table(
-        border: TableBorder.all(color: Colors.black),
+        border: TableBorder.all(color: Colors.black26),
         columnWidths: const <int, TableColumnWidth>{
           // 0: IntrinsicColumnWidth(),
           0: FlexColumnWidth(1),
@@ -17,15 +17,25 @@ class ShiftTable {
           TableRow(children: [
             TableCell(
                 child: Container(
-              child: Text("日時"),
+              child: Text(
+                "日時",
+                style: TextStyle(
+                  color: Colors.white,
+                ),
+              ),
               alignment: Alignment.center,
-              color: Colors.teal,
+              color: Colors.orangeAccent,
             )),
             TableCell(
               child: Container(
-                child: Text("シフト"),
+                child: Text(
+                  "シフト",
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
                 alignment: Alignment.center,
-                color: Colors.teal,
+                color: Colors.orangeAccent,
               ),
             )
           ]),
@@ -55,21 +65,35 @@ class ShiftTable {
                     ),
                     child: TextButton(
                         child: new Text(shifts[index]["Work"].toString()),
-                        style: ElevatedButton.styleFrom(
-                          onPrimary: Colors.teal,
-                        ),
+                        style: ElevatedButton.styleFrom(onPrimary: Colors.amber
+                            //HexColor(shifts[index]["Color"].toString()),
+                            ),
                         onPressed: () async {
-                          logger.i(shifts[index]["Work"]);
-                          await openShiftDialog(
-                              context,
-                              shifts[index]["WorkID"],
-                              shifts[index]["UserID"],
-                              shifts[index]["Date"],
-                              shifts[index]["Weather"],
-                              shifts[index]["Time"]);
+                          if (shifts[index]["Work"] != "") {
+                            logger.i(shifts[index]["Work"]);
+                            await openShiftDialog(
+                                context,
+                                shifts[index]["WorkID"],
+                                shifts[index]["UserID"],
+                                shifts[index]["Date"],
+                                shifts[index]["Weather"],
+                                shifts[index]["Time"]);
+                          }
                         }),
                   ))
                 ]),
         ]);
   }
+}
+
+class HexColor extends Color {
+  static int _getColorFromHex(String hexColor) {
+    hexColor = hexColor.toUpperCase().replaceAll('#', '');
+    if (hexColor.length == 6) {
+      hexColor = 'FF' + hexColor;
+    }
+    return int.parse(hexColor, radix: 16);
+  }
+
+  HexColor(final String hexColor) : super(_getColorFromHex(hexColor));
 }


### PR DESCRIPTION
# 概要
シフトごとに背景色を割り当てる
空きシフトのダイアログを開かないように変更

# スクリーンショット
![localhost_58585_(iPhone 6_7_8)](https://user-images.githubusercontent.com/66663224/135337505-dc7d0bea-2426-45dc-a1db-2aca1d22bcf7.png)
