### PR TITLE
[fix]create cleanup day time schedule(#36)

### DIFF
--- a/lib/pages/cleanup_day_time_schedule.dart
+++ b/lib/pages/cleanup_day_time_schedule.dart
@@ -1,0 +1,1685 @@
+import 'dart:developer';
+import 'dart:ui';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class CleanUpDayTimeSchedule extends StatefulWidget {
+  @override
+  _MyShiftPageState createState() => _MyShiftPageState();
+}
+
+class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Container(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: Column(
+              children: <Widget>[
+                Container(
+                  child: Table(
+                    border: TableBorder.all(color: Colors.black),
+                    columnWidths: const <int, TableColumnWidth>{
+                      // 0: IntrinsicColumnWidth(),
+                      0: FixedColumnWidth(80),
+                      1: FixedColumnWidth(100),
+                      2: FixedColumnWidth(100),
+                      3: FixedColumnWidth(100),
+                      4: FixedColumnWidth(100),
+                      5: FixedColumnWidth(100),
+                      6: FixedColumnWidth(100),
+                      7: FixedColumnWidth(100),
+                    },
+                    defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                    children: [
+                      // 1行目 チーム
+                      TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "本部",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Aチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Bチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Cチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Dチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Eチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "Fチーム",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      // 2行目 リーダー
+                      TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "リーダー",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "市原",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "小黒",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "鵜澤",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "長島",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "安達・野上",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "前川",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "吉川",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      // 3行目 補佐
+                      TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "補佐",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "杉本",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "政木",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "真下",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "佐々木",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "氏家",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "水上",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "宇野",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      // 4行目 人数
+                      TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "人数",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "4人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "16人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "14人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "12人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "10",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "10人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text(
+                                "12人",
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      // 5行目 ここからシフト 8:00~8:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.grey[200]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "8:00\n~8:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "朝食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 6行目 8:30~9:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.grey[200]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "8:30\n~9:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "MT",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 7行目 9:00~9:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "9:00\n~9:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                              child: Container(
+                                child: new Text(
+                                  "本部\n\n本部",
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                            TableCell(
+                                child: Container(
+                                  child: new Text(
+                                    "参加団体\n物品返却\n\n講義棟\n\n16人",
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                            ),
+                            TableCell(
+                                child: Container(
+                                  child: new Text(
+                                    "机・イス運搬\n\n講義棟\n\n14人",
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                            ),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n体育館\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "制作物撤去\n\nその他\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 8行目 9:30~10:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "9:30\n~10:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "参加団体\n物品返却\n\n講義棟\n\n16人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n14人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n体育館\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "制作物撤去\n\nその他\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 9行目 10:00~10:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "10:00\n~10:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "参加団体\n物品返却\n\n講義棟\n\n16人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n14人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n体育館\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "イス，音響\n片付け\n\n体育館\n\n20人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "制作物撤去\n\nその他\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 10行目 10:30~11:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "10:30\n~11:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n16人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n14人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n体育館\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ステージ解体\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "物品運搬\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "制作物撤去\n\nその他\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 11行目 11:00~11:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "11:00\n~11:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n16人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n14人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "D講, AL23\n片付け\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ステージ解体\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "物品運搬\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 12行目 11:30~12:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "11:30\n~12:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n16人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "机・イス運搬\n\n講義棟\n\n14人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "D講, AL23\n片付け\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ステージ解体\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "物品運搬\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 13行目 12:00~12:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "12:00\n~12:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "D講, AL23\n片付け\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ステージ解体\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "物品運搬\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 14行目 12:30~13:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "12:30\n~13:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "検温所撤去\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 15行目 13:00~13:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "13:00\n~13:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 16行目 13:30~14:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "13:30\n~14:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "掃除\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シートはがし\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部解体\n\n本部\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "昼食",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 17行目 14:00~14:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "14:00\n~14:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "3F現状復帰\n\n講義棟\n\n30人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "掃除\n\n講義棟\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シートはがし\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部解体\n\n本部\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "24下倉庫\n片付け\n\n本部\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 18行目 14:30~15:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "14:30\n~15:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部\n\n本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シートはがし\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部解体\n\n本部\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "24下倉庫\n片付け\n\n本部\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 19行目 15:00~15:30
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "15:00\n~15:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シートはがし\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部解体\n\n本部\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "24下倉庫\n片付け\n\n本部\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                      // 20行目 15:30~16:00
+                      TableRow(
+                          decoration: BoxDecoration(color: Colors.white60),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "15:30\n~16:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シールはがし\n\n講義棟\n\n42人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "シートはがし\n\n体育館\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "本部解体\n\n本部\n\n10人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "24下倉庫\n片付け\n\n本部\n\n12人",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                          // 21行目 集合写真
+                          TableRow(
+                          decoration: BoxDecoration(color: Colors.grey[200]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "16:00\n~16:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "集合写真",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                          // 22行目 ビンゴ受付
+                          TableRow(
+                          decoration: BoxDecoration(color: Colors.orange[100]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "16:30\n~17:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ受付",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                          // 23行目 ビンゴ
+                          TableRow(
+                          decoration: BoxDecoration(color: Colors.orange[100]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "17:00\n~17:30",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                          // 24行目 ビンゴ
+                          TableRow(
+                          decoration: BoxDecoration(color: Colors.orange[100]),
+                          children: [
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "17:30\n~18:00",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                            TableCell(
+                                child: Container(
+                              child: new Text(
+                                "ビンゴ",
+                                textAlign: TextAlign.center,
+                              ),
+                            )),
+                          ]),
+
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/cleanup_day_time_schedule.dart
+++ b/lib/pages/cleanup_day_time_schedule.dart
@@ -396,7 +396,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                           TableCell(
                             child: Container(
                               child: Text(
-                                "10",
+                                "10人",
                                 textAlign: TextAlign.center,
                                 style: TextStyle(
                                   color: Colors.white,
@@ -567,7 +567,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                               child: Container(
                                 child: new Text(
-                                  "本部\n\n本部",
+                                  "本部",
                                   textAlign: TextAlign.center,
                                 ),
                               ),
@@ -632,7 +632,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -694,7 +694,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -756,7 +756,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -818,7 +818,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -880,7 +880,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -1066,7 +1066,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),
@@ -1252,7 +1252,7 @@ class _MyShiftPageState extends State<CleanUpDayTimeSchedule> {
                             TableCell(
                                 child: Container(
                               child: new Text(
-                                "本部\n\n本部",
+                                "本部",
                                 textAlign: TextAlign.center,
                               ),
                             )),

--- a/lib/pages/my_shift_page.dart
+++ b/lib/pages/my_shift_page.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:seeft_mobile/pages/my_shift_page_preparation_day.dart';
 import 'package:seeft_mobile/pages/my_shift_page_current_day.dart';
 import 'package:seeft_mobile/pages/pre_preparation_day_shift.dart';
+import 'package:seeft_mobile/pages/cleanup_day_time_schedule.dart';
 /*
 import 'package:seeft_mobile/pages/my_shift_page_preparation_day_sunny.dart';
 import 'package:seeft_mobile/pages/my_shift_page_preparation_day_rainy.dart';
@@ -29,6 +30,7 @@ class _MyShiftPageState extends State<MyShiftPage>
     TabInfo("準々備日", PrePreparationDayShift()),
     TabInfo("準備日", MyShiftPagePreparationDay()),
     TabInfo("当日", MyShiftPageCurrentDay()),
+    TabInfo("片付け日", CleanUpDayTimeSchedule()),
   ];
   late TabController _tabController;
 // notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね


### PR DESCRIPTION
# やったこと
- 片付け日のシフト表を作成した。
  - 全体で共通のシフトの場合は同じ色にした（朝食・MT・集合写真：グレー、ビンゴ受付・ビンゴ：オレンジ）（画像2枚目）
  - 同じ項目のセルの統合とセルごとに色を変えることはできなかったので、一旦この状態でpushします。

![image](https://user-images.githubusercontent.com/71711872/135445962-671a39f7-6071-478a-bad6-35bfc7563f0c.png)
![image](https://user-images.githubusercontent.com/71711872/135446007-5b7c803a-b099-4d23-8dcc-ef3486d690bb.png)

