### PR TITLE
[fix]シフト完成待ち画面の作成とメニュー遷移先の修正

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,1 @@
-/Users/p162/fvm/versions/2.10.4
+/home/harata/fvm/versions/2.10.4

--- a/lib/configs/constant.dart
+++ b/lib/configs/constant.dart
@@ -2,6 +2,6 @@ Constant constant = Constant();
 
 class Constant {
   final String appName = "SeeFT";
-  final String apiUrl = "http://118.27.15.89:3000/";
+  final String apiUrl = "https://seeft-api.mashita1023.net/";
 //  final String apiUrl = "https://seeft-api.nutfes.net/";
 }

--- a/lib/pages/all_shift_page.dart
+++ b/lib/pages/all_shift_page.dart
@@ -29,59 +29,7 @@ class _AllShiftPageState extends State<AllShiftPage> {
         actions: <Widget>[],
         // debug
       ),
-      drawer: Drawer(
-          child: ListView(
-        children: <Widget>[
-          ListTile(
-            title: Text("マイシフト"),
-            leading: const Icon(Icons.dvr),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/my_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("全体シフト"),
-            leading: Icon(Icons.dynamic_feed),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/all_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("マニュアル一覧"),
-            leading: Icon(Icons.list_alt),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/manual_list_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("タイムスケジュール"),
-            leading: Icon(Icons.schedule),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/schedule_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("本部連絡先"),
-            leading: Icon(Icons.contact_phone),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/contact_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("再ログイン"),
-            leading: Icon(Icons.login),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (Route<dynamic> route) => false)
-            },
-          ),
-        ],
-      )),
+      drawer: drawer.applicationDrawer(context),
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {

--- a/lib/pages/manual_list_page.dart
+++ b/lib/pages/manual_list_page.dart
@@ -31,59 +31,7 @@ class _ManualListPageState extends State<ManualListPage> {
         actions: <Widget>[],
         // debug
       ),
-      drawer: Drawer(
-          child: ListView(
-        children: <Widget>[
-          ListTile(
-            title: Text("マイシフト"),
-            leading: const Icon(Icons.dvr),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/my_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("全体シフト"),
-            leading: Icon(Icons.dynamic_feed),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/all_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("マニュアル一覧"),
-            leading: Icon(Icons.list_alt),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/manual_list_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("タイムスケジュール"),
-            leading: Icon(Icons.schedule),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/schedule_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("本部連絡先"),
-            leading: Icon(Icons.contact_phone),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/contact_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("再ログイン"),
-            leading: Icon(Icons.login),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (Route<dynamic> route) => false)
-            },
-          ),
-        ],
-      )),
+      drawer: drawer.applicationDrawer(context),
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {

--- a/lib/pages/schedule_page.dart
+++ b/lib/pages/schedule_page.dart
@@ -29,59 +29,7 @@ class _SchedulePageState extends State<SchedulePage> {
         actions: <Widget>[],
         // debug
       ),
-      drawer: Drawer(
-          child: ListView(
-        children: <Widget>[
-          ListTile(
-            title: Text("マイシフト"),
-            leading: const Icon(Icons.dvr),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/my_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("全体シフト"),
-            leading: Icon(Icons.dynamic_feed),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/all_shift_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("マニュアル一覧"),
-            leading: Icon(Icons.list_alt),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/manual_list_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("タイムスケジュール"),
-            leading: Icon(Icons.schedule),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/schedule_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("本部連絡先"),
-            leading: Icon(Icons.contact_phone),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/contact_page', (Route<dynamic> route) => false)
-            },
-          ),
-          ListTile(
-            title: Text("再ログイン"),
-            leading: Icon(Icons.login),
-            onTap: () => {
-              Navigator.pushNamedAndRemoveUntil(
-                  context, '/', (Route<dynamic> route) => false)
-            },
-          ),
-        ],
-      )),
+      drawer: drawer.applicationDrawer(context),
       body: FutureBuilder(
         future: getData(),
         builder: (ctx, snapshot) {

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -22,7 +22,8 @@ class _SignInPageState extends State<SignInPage> {
         infoText = "Your ID : ${userID}";
       });
       Navigator.pushNamedAndRemoveUntil(
-          context, '/my_shift_page', (Route<dynamic> route) => false);
+        context, '/wait_page', (Route<dynamic> route) => false);
+//          context, '/my_shift_page', (Route<dynamic> route) => false);
     } catch (e) {
       setState(() {
         ScaffoldMessenger.of(context).showSnackBar(const SnackBar(

--- a/lib/pages/wait_page.dart
+++ b/lib/pages/wait_page.dart
@@ -1,0 +1,38 @@
+import 'package:seeft_mobile/configs/importer.dart';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class WaitPage extends StatefulWidget {
+  @override
+  _WaitPageState createState() => new _WaitPageState();
+}
+
+class _WaitPageState extends State<WaitPage> {
+    int manualLength = 0;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('マニュアル一覧'),
+        actions: <Widget>[],
+        // debug
+      ),
+      drawer: drawer.applicationDrawer(context),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children:[ Text("「シフトが完成するまでお待ちください」",style: TextStyle(fontSize: 40),),],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/wait_page.dart
+++ b/lib/pages/wait_page.dart
@@ -22,7 +22,7 @@ class _WaitPageState extends State<WaitPage> {
     final Size size = MediaQuery.of(context).size;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('マニュアル一覧'),
+        title: const Text(''),
         actions: <Widget>[],
         // debug
       ),

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -12,40 +12,40 @@ class ApplicationDrawer {
           title: Text("マイシフト"),
           leading: const Icon(Icons.dvr),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/my_shift_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/my_shift_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(
           title: Text("全体シフト"),
           leading: Icon(Icons.dynamic_feed),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/all_shift_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/all_shift_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(
           title: Text("マニュアル一覧"),
           leading: Icon(Icons.list_alt),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/manual_list_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/manual_list_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(
           title: Text("タイムスケジュール"),
           leading: Icon(Icons.schedule),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/schedule_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/schedule_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(
           title: Text("本部連絡先"),
           leading: Icon(Icons.contact_phone),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/contact_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/contact_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(

--- a/lib/widgets/first_jump_selector.dart
+++ b/lib/widgets/first_jump_selector.dart
@@ -7,6 +7,7 @@ import 'package:seeft_mobile/pages/all_shift_page.dart';
 import 'package:seeft_mobile/pages/manual_list_page.dart';
 import 'package:seeft_mobile/pages/schedule_page.dart';
 import 'package:seeft_mobile/pages/contact_page.dart';
+import 'package:seeft_mobile/pages/wait_page.dart';
 
 class FirstJumpSelector extends StatefulWidget {
   @override
@@ -43,8 +44,10 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
         logger.i(snapshot.connectionState);
         var homeWidget;
         if (isUserID!) {
-          logger.i('select SignInPage.');
-          homeWidget = '/my_shift_page';
+          // logger.i('select SignInPage.');
+          // homeWidget = '/my_shift_page';
+          logger.i('select WaitPage.');
+          homeWidget = '/wait_page';
         } else {
           logger.i('select MainPage.');
           homeWidget = '/signin';
@@ -77,6 +80,7 @@ class _FirstJumpSelectorState extends State<FirstJumpSelector> {
             '/manual_list_page': (context) => ManualListPage(),
             '/schedule_page': (context) => SchedulePage(),
             '/contact_page': (context) => ContactPage(),
+            '/wait_page': (context) => WaitPage(),
           },
         );
 

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   url_launcher_windows
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -14,3 +17,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,9 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   url_launcher_windows
 )
 
-list(APPEND FLUTTER_FFI_PLUGIN_LIST
-)
-
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -17,8 +14,3 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
-
-foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
-  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
-  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
-endforeach(ffi_plugin)


### PR DESCRIPTION
resolve #76 


# 概要
ログインした後にシフト完成待ち画面を表示するようにした。
各ページのメニュにある再ログインとヘルプ以外の遷移先を変更した。