### PR TITLE
[feature]当日（と片付け日）のシフト表の表示(#88)

### DIFF
--- a/lib/pages/my_shift_page_current_first_day.dart
+++ b/lib/pages/my_shift_page_current_first_day.dart
@@ -3,63 +3,61 @@ import 'dart:developer';
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeft_mobile/pages/my_shift_page_current_first_day_rainy.dart';
+import 'package:seeft_mobile/pages/my_shift_page_current_first_day_sunny.dart';
 
 class MyShiftPageCurrentFirstDay extends StatefulWidget {
   @override
   _MyShiftPageState createState() => _MyShiftPageState();
 }
 
-class _MyShiftPageState extends State<MyShiftPageCurrentFirstDay> {
-// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+class TabInfo {
+  String label;
+  Widget widget;
 
-//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
-//  NotificationDetails platformChannelSpecifics;
+  TabInfo(this.label, this.widget);
+}
+
+class _MyShiftPageState extends State<MyShiftPageCurrentFirstDay>
+    with SingleTickerProviderStateMixin {
+  final List<TabInfo> _tabs = [
+    TabInfo("晴れ", MyShiftPageCurrentFirstDaySunny()),
+    TabInfo("雨", MyShiftPageCurrentFirstDayRainy()),
+  ];
+  late TabController _tabController;
+
+  // notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+  //  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+  //  NotificationDetails platformChannelSpecifics;
 
   @override
   void initState() {
+    _tabController = TabController(length: _tabs.length, vsync: this);
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     final Size size = MediaQuery.of(context).size;
-    return FutureBuilder(
-      future: getData(),
-      builder: (ctx, snapshot) {
-        if (snapshot.connectionState == AsyncSnapshot.waiting()) {
-          logger.w("message");
-        }
-        if (!snapshot.hasData) {
-          return CircularProgressIndicator();
-        }
-        return Container(
-            padding: const EdgeInsets.all(40.0),
-            child: SingleChildScrollView(
-              child: Column(
-                children: <Widget>[
-                  Container(
-                      // height: size.height - 200,
-                      // width: size.width - 80,
-                      // padding: const EdgeInsets.all(10.0),
-                      // decoration: BoxDecoration(
-                      //   border: Border.all(color: Colors.black),
-                      // ),
-                      // child: _contents(size, snapshot.data)),
-                      child: table.shiftTable(snapshot.data, context)),
-                ],
-              ),
-            ));
-      },
+    return Scaffold(
+      appBar: AppBar(
+        actions: <Widget>[],
+        bottom: PreferredSize(
+          child: TabBar(
+            isScrollable: true,
+            tabs: _tabs.map((TabInfo tab) {
+              return Tab(text: tab.label);
+            }).toList(),
+            controller: _tabController,
+          ),
+          preferredSize: Size.fromHeight(10.0),
+        ),
+        // debug
+      ),
+      body: TabBarView(
+          controller: _tabController,
+          children: _tabs.map((tab) => tab.widget).toList()),
     );
-  }
-}
-
-Future getData() async {
-  try {
-    var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDay(userID.toString());
-    return res;
-  } catch (err) {
-    logger.e('don`t response. error message: $err');
   }
 }

--- a/lib/pages/my_shift_page_current_first_day_rainy.dart
+++ b/lib/pages/my_shift_page_current_first_day_rainy.dart
@@ -57,7 +57,7 @@ class _MyShiftPageState extends State<MyShiftPageCurrentFirstDayRainy> {
 Future getData() async {
   try {
     var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDayRainy(userID.toString());
+    var res = await api.getMyShiftCurrentFirstDayRainy(userID.toString());
     return res;
   } catch (err) {
     logger.e('don`t response. error message: $err');

--- a/lib/pages/my_shift_page_current_first_day_sunny.dart
+++ b/lib/pages/my_shift_page_current_first_day_sunny.dart
@@ -57,7 +57,7 @@ class _MyShiftPageState extends State<MyShiftPageCurrentFirstDaySunny> {
 Future getData() async {
   try {
     var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDaySunny(userID.toString());
+    var res = await api.getMyShiftCurrentFirstDaySunny(userID.toString());
     return res;
   } catch (err) {
     logger.e('don`t response. error message: $err');

--- a/lib/pages/my_shift_page_current_second_day.dart
+++ b/lib/pages/my_shift_page_current_second_day.dart
@@ -3,63 +3,61 @@ import 'dart:developer';
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeft_mobile/pages/my_shift_page_current_second_day_rainy.dart';
+import 'package:seeft_mobile/pages/my_shift_page_current_second_day_sunny.dart';
 
 class MyShiftPageCurrentSecondDay extends StatefulWidget {
   @override
   _MyShiftPageState createState() => _MyShiftPageState();
 }
 
-class _MyShiftPageState extends State<MyShiftPageCurrentSecondDay> {
-// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+class TabInfo {
+  String label;
+  Widget widget;
 
-//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
-//  NotificationDetails platformChannelSpecifics;
+  TabInfo(this.label, this.widget);
+}
+
+class _MyShiftPageState extends State<MyShiftPageCurrentSecondDay>
+    with SingleTickerProviderStateMixin {
+  final List<TabInfo> _tabs = [
+    TabInfo("晴れ", MyShiftPageCurrentSecondDaySunny()),
+    TabInfo("雨", MyShiftPageCurrentSecondDayRainy()),
+  ];
+  late TabController _tabController;
+
+  // notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+  //  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+  //  NotificationDetails platformChannelSpecifics;
 
   @override
   void initState() {
+    _tabController = TabController(length: _tabs.length, vsync: this);
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     final Size size = MediaQuery.of(context).size;
-    return FutureBuilder(
-      future: getData(),
-      builder: (ctx, snapshot) {
-        if (snapshot.connectionState == AsyncSnapshot.waiting()) {
-          logger.w("message");
-        }
-        if (!snapshot.hasData) {
-          return CircularProgressIndicator();
-        }
-        return Container(
-            padding: const EdgeInsets.all(40.0),
-            child: SingleChildScrollView(
-              child: Column(
-                children: <Widget>[
-                  Container(
-                      // height: size.height - 200,
-                      // width: size.width - 80,
-                      // padding: const EdgeInsets.all(10.0),
-                      // decoration: BoxDecoration(
-                      //   border: Border.all(color: Colors.black),
-                      // ),
-                      // child: _contents(size, snapshot.data)),
-                      child: table.shiftTable(snapshot.data, context)),
-                ],
-              ),
-            ));
-      },
+    return Scaffold(
+      appBar: AppBar(
+        actions: <Widget>[],
+        bottom: PreferredSize(
+          child: TabBar(
+            isScrollable: true,
+            tabs: _tabs.map((TabInfo tab) {
+              return Tab(text: tab.label);
+            }).toList(),
+            controller: _tabController,
+          ),
+          preferredSize: Size.fromHeight(10.0),
+        ),
+        // debug
+      ),
+      body: TabBarView(
+          controller: _tabController,
+          children: _tabs.map((tab) => tab.widget).toList()),
     );
-  }
-}
-
-Future getData() async {
-  try {
-    var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDay(userID.toString());
-    return res;
-  } catch (err) {
-    logger.e('don`t response. error message: $err');
   }
 }

--- a/lib/pages/my_shift_page_current_second_day_rainy.dart
+++ b/lib/pages/my_shift_page_current_second_day_rainy.dart
@@ -57,7 +57,7 @@ class _MyShiftPageState extends State<MyShiftPageCurrentSecondDayRainy> {
 Future getData() async {
   try {
     var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDayRainy(userID.toString());
+    var res = await api.getMyShiftCurrentSecondDayRainy(userID.toString());
     return res;
   } catch (err) {
     logger.e('don`t response. error message: $err');

--- a/lib/pages/my_shift_page_current_second_day_sunny.dart
+++ b/lib/pages/my_shift_page_current_second_day_sunny.dart
@@ -57,7 +57,7 @@ class _MyShiftPageState extends State<MyShiftPageCurrentSecondDaySunny> {
 Future getData() async {
   try {
     var userID = await store.getUserID();
-    var res = await api.getMyShiftCurrentDaySunny(userID.toString());
+    var res = await api.getMyShiftCurrentSecondDaySunny(userID.toString());
     return res;
   } catch (err) {
     logger.e('don`t response. error message: $err');

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -96,9 +96,11 @@ class Api {
     }
   }
 
-  // 当日シフト
-  Future getMyShiftCurrentDay(id) async {
-    String url = constant.apiUrl + 'shift/' + id + '/currentDay';
+  // 当日1日目晴れシフト
+  Future getMyShiftCurrentFirstDaySunny(id) async {
+    // 一旦準備日のseedデータを使用
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/2/weathers/1';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -108,9 +110,11 @@ class Api {
     }
   }
 
-  // 当日晴れシフト
-  Future getMyShiftCurrentDaySunny(id) async {
-    String url = constant.apiUrl + 'shift/' + id + '/currentDay' + '/sunny';
+  // 当日1日目雨シフト
+  Future getMyShiftCurrentFirstDayRainy(id) async {
+    // 一旦準備日のseedデータを使用
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/2/weathers/2';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -120,9 +124,25 @@ class Api {
     }
   }
 
-  // 当日雨シフト
-  Future getMyShiftCurrentDayRainy(id) async {
-    String url = constant.apiUrl + 'shift/' + id + '/currentDay' + '/rainy';
+  // 当日2日目晴れシフト
+  Future getMyShiftCurrentSecondDaySunny(id) async {
+    // 一旦準備日のseedデータを使用
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/3/weathers/1';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
+    try {
+      return await get(url);
+    } catch (err) {
+      logger.e(err);
+      // calling api.get みたいに呼び出し元参照できるようにしたい
+      throw err;
+    }
+  }
+
+  // 当日2日目雨シフト
+  Future getMyShiftCurrentSecondDayRainy(id) async {
+    // 一旦準備日のseedデータを使用
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/3/weathers/2';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -134,7 +154,9 @@ class Api {
 
   // 片付け日シフト
   Future getMyShiftCleanupDay(id) async {
-    String url = constant.apiUrl + 'shift/' + id + '/cleanupDay';
+    // 一旦準備日のseedデータを使用
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/4/weathers/1';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -12,8 +12,8 @@ class ApplicationDrawer {
           title: Text("マイシフト"),
           leading: const Icon(Icons.dvr),
           onTap: () => {
-            // Navigator.pushNamedAndRemoveUntil(
-            //     context, '/my_shift_page', (Route<dynamic> route) => false)
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/my_shift_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(


### PR DESCRIPTION
- 当日 1日目（晴れ・雨）
- 当日 2日目（晴れ・雨）

のシフト表をそれぞれ表示するようにしました。
ただseedデータがないので、とりあえず準備日のデータを表示させています。
また片付け日については現在`cleanup_day_time_schedule.dart`が参照されてますが、とりあえず`my_shift_page_cleanup_day.dart`が参照されてもいいように編集しました。