### PR TITLE
[Feature]シフトの詳細をダイアログで表示(#93)

### DIFF
--- a/lib/pages/schedule_page.dart
+++ b/lib/pages/schedule_page.dart
@@ -3,20 +3,39 @@ import 'dart:developer';
 import 'package:seeft_mobile/configs/importer.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:http/http.dart' as http;
+import 'package:seeft_mobile/pages/schedule_page_first_day_rainy.dart';
+import 'package:seeft_mobile/pages/schedule_page_first_day_sunny.dart';
+import 'package:seeft_mobile/pages/schedule_page_second_day_rainy.dart';
+import 'package:seeft_mobile/pages/schedule_page_second_day_sunny.dart';
 
 class SchedulePage extends StatefulWidget {
   @override
   _SchedulePageState createState() => _SchedulePageState();
 }
 
-class _SchedulePageState extends State<SchedulePage> {
-// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+class TabInfo {
+  String label;
+  Widget widget;
+  TabInfo(this.label, this.widget);
+}
+
+class _SchedulePageState extends State<SchedulePage>   with SingleTickerProviderStateMixin {
+  final List<TabInfo> _tabs = [
+    TabInfo("9/10 晴天時", SchedulePageFirstDaySunny()),
+    TabInfo("9/10 雨天時", SchedulePageFirstDayRainy()),
+    TabInfo("9/11 晴天時", SchedulePageSecondDaySunny()),
+    TabInfo("9/11 雨天時", SchedulePageSecondDayRainy()),
+  ];
+  late TabController _tabController;
+
+  // notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
 
 //  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 //  NotificationDetails platformChannelSpecifics;
 
   @override
   void initState() {
+    _tabController = TabController(length: _tabs.length, vsync: this);
     super.initState();
   }
 
@@ -27,93 +46,22 @@ class _SchedulePageState extends State<SchedulePage> {
       appBar: AppBar(
         title: const Text('タイムスケジュール'),
         actions: <Widget>[],
+        bottom: PreferredSize(
+          child: TabBar(
+            isScrollable: true,
+            tabs: _tabs.map((TabInfo tab) {
+              return Tab(text: tab.label);
+            }).toList(),
+            controller: _tabController,
+          ),
+          preferredSize: Size.fromHeight(30.0),
+        ),
         // debug
       ),
       drawer: drawer.applicationDrawer(context),
-      body: FutureBuilder(
-        future: getData(),
-        builder: (ctx, snapshot) {
-          if (snapshot.connectionState == AsyncSnapshot.waiting()) {
-            logger.w("message");
-          }
-          if (!snapshot.hasData) {
-            return CircularProgressIndicator();
-          }
-          return Container(
-              padding: const EdgeInsets.all(40.0),
-              child: SingleChildScrollView(
-                child: Column(
-                  children: <Widget>[
-                    Container(
-                        // height: size.height - 200,
-                        // width: size.width - 80,
-                        // padding: const EdgeInsets.all(10.0),
-                        // decoration: BoxDecoration(
-                        //   border: Border.all(color: Colors.black),
-                        // ),
-                        // child: _contents(size, snapshot.data)),
-                        child: _table(snapshot.data)),
-                  ],
-                ),
-              ));
-        },
-      ),
+      body: TabBarView(
+          controller: _tabController,
+          children: _tabs.map((tab) => tab.widget).toList()),
     );
-  }
-}
-
-Widget _table(var shifts) {
-  return Table(
-      border: TableBorder.all(color: Colors.black),
-      columnWidths: const <int, TableColumnWidth>{
-        // 0: IntrinsicColumnWidth(),
-        0: FlexColumnWidth(1),
-        1: FlexColumnWidth(10),
-        // 2: FixedColumnWidth(100.0),
-      },
-      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
-      children: [
-        TableRow(children: [
-          TableCell(
-              child: Container(
-            child: Text("日時"),
-            alignment: Alignment.center,
-            color: Colors.lightGreen,
-          )),
-          TableCell(
-            child: Container(
-              child: Text("場所"),
-              alignment: Alignment.center,
-              color: Colors.lightGreen,
-            ),
-          )
-        ]),
-        for (var shift in shifts)
-          TableRow(
-              decoration: BoxDecoration(color: Colors.grey[200]),
-              children: [
-                TableCell(
-                    child: Container(
-                  alignment: Alignment.center,
-                  child: new Text(shift["Time"].toString()),
-                )),
-                TableCell(
-                    child: Container(
-                  alignment: Alignment.center,
-                  child: new Text(shift["Work"].toString()),
-                  // margin: EdgeInsets.only(bottom: 10.0),
-                  height: 25,
-                ))
-              ]),
-      ]);
-}
-
-Future getData() async {
-  try {
-    var userID = await store.getUserID();
-    var res = await api.getMyShift(userID.toString());
-    return res;
-  } catch (err) {
-    logger.e('don`t response. error message: $err');
   }
 }

--- a/lib/pages/schedule_page_first_day_rainy.dart
+++ b/lib/pages/schedule_page_first_day_rainy.dart
@@ -34,39 +34,582 @@ class _SchedulePageFirstDayRainyState extends State<SchedulePageFirstDayRainy> {
               Container(
                 child: Table(
                   border: TableBorder.all(color: Colors.black),
-                  columnWidths: const<int, TableColumnWidth>{
-                    0: FlexColumnWidth(5),
-                    1: FlexColumnWidth(10),
-                    2: FlexColumnWidth(10),
-                    3: FlexColumnWidth(10),
+                  columnWidths: const <int, TableColumnWidth>{
+                    0: FlexColumnWidth(10),
+                    1: FlexColumnWidth(15),
+                    2: FlexColumnWidth(15),
+                    3: FlexColumnWidth(15),
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
+                    TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                              child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                          )),
+                          TableCell(
+                            child: Container(
+                              child: Text("体育館"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("A講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("D講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                        ]),
+
+                    // 2行目
                     TableRow(children: [
                       TableCell(
                           child: Container(
-                            child: Text("日時"),
-                            alignment: Alignment.center,
-                            color: Colors.lightGreen,
-                          )
-                      ),
+                        child: Text("10:00~\n10:30"),
+                        alignment: Alignment.center,
+                      )),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("体育館"),
+                          child: Text("悠久太鼓愛好会\n鶴亀会"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("A講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Popular Music Club"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 3行目
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                        child: Text("10:30~\n11:00"),
+                        alignment: Alignment.center,
+                      )),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("合唱サークル"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("D講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 4行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:00~\n11:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 5行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:15~\n11:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Mexico"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 6行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:30~\n12:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 7行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:00~\n12:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Street Style"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 8行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:30~\n13:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 9行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:00~\n13:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 10行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:30~\n14:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Sri Lanka"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 12行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:00~\n14:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 11行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:30~\n15:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("吹奏楽部"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 13行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:00~\n15:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 14行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:30~\n16:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:00~\n16:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 16行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:30~\n17:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("ヒーローショー"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:00~\n17:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:30~\n18:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),

--- a/lib/pages/schedule_page_first_day_rainy.dart
+++ b/lib/pages/schedule_page_first_day_rainy.dart
@@ -1,0 +1,84 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class SchedulePageFirstDayRainy extends StatefulWidget {
+  @override
+  _SchedulePageFirstDayRainyState createState() =>
+      _SchedulePageFirstDayRainyState();
+}
+
+class _SchedulePageFirstDayRainyState extends State<SchedulePageFirstDayRainy> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      child: Container(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Column(
+            children: <Widget>[
+              Container(
+                child: Table(
+                  border: TableBorder.all(color: Colors.black),
+                  columnWidths: const<int, TableColumnWidth>{
+                    0: FlexColumnWidth(5),
+                    1: FlexColumnWidth(10),
+                    2: FlexColumnWidth(10),
+                    3: FlexColumnWidth(10),
+                  },
+                  defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                            color: Colors.lightGreen,
+                          )
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("体育館"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("A講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("D講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/schedule_page_first_day_sunny.dart
+++ b/lib/pages/schedule_page_first_day_sunny.dart
@@ -1,0 +1,91 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class SchedulePageFirstDaySunny extends StatefulWidget {
+  @override
+  _SchedulePageFirstDaySunnyState createState() => _SchedulePageFirstDaySunnyState();
+}
+
+class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      child: Container(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Column(
+            children: <Widget>[
+              Container(
+                child: Table(
+                  border: TableBorder.all(color: Colors.black),
+                  columnWidths: const<int, TableColumnWidth>{
+                    0: FlexColumnWidth(5),
+                    1: FlexColumnWidth(10),
+                    2: FlexColumnWidth(10),
+                    3: FlexColumnWidth(10),
+                    4: FlexColumnWidth(10),
+                  },
+                  defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                            color: Colors.lightGreen,
+                          )
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("メインステージ"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("体育館"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("A講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("D講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/schedule_page_first_day_sunny.dart
+++ b/lib/pages/schedule_page_first_day_sunny.dart
@@ -35,11 +35,11 @@ class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
                 child: Table(
                   border: TableBorder.all(color: Colors.black),
                   columnWidths: const <int, TableColumnWidth>{
-                    0: FlexColumnWidth(5),
-                    1: FlexColumnWidth(10),
-                    2: FlexColumnWidth(10),
-                    3: FlexColumnWidth(10),
-                    4: FlexColumnWidth(10),
+                    0: FlexColumnWidth(10),
+                    1: FlexColumnWidth(15),
+                    2: FlexColumnWidth(15),
+                    3: FlexColumnWidth(15),
+                    4: FlexColumnWidth(15),
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
@@ -486,6 +486,241 @@ class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
                           child: Text("吹奏楽部"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 13行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:00~\n15:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 14行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:30~\n16:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:00~\n16:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 16行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:30~\n17:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("ヒーローショー"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:00~\n17:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:30~\n18:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                       TableCell(

--- a/lib/pages/schedule_page_first_day_sunny.dart
+++ b/lib/pages/schedule_page_first_day_sunny.dart
@@ -6,7 +6,8 @@ import 'package:http/http.dart' as http;
 
 class SchedulePageFirstDaySunny extends StatefulWidget {
   @override
-  _SchedulePageFirstDaySunnyState createState() => _SchedulePageFirstDaySunnyState();
+  _SchedulePageFirstDaySunnyState createState() =>
+      _SchedulePageFirstDaySunnyState();
 }
 
 class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
@@ -33,7 +34,7 @@ class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
               Container(
                 child: Table(
                   border: TableBorder.all(color: Colors.black),
-                  columnWidths: const<int, TableColumnWidth>{
+                  columnWidths: const <int, TableColumnWidth>{
                     0: FlexColumnWidth(5),
                     1: FlexColumnWidth(10),
                     2: FlexColumnWidth(10),
@@ -42,38 +43,462 @@ class _SchedulePageFirstDaySunnyState extends State<SchedulePageFirstDaySunny> {
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
+                    TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                              child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                          )),
+                          TableCell(
+                            child: Container(
+                              child: Text("メインステージ"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("体育館"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("A講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("D講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                        ]),
+
+                    // 2行目
                     TableRow(children: [
                       TableCell(
                           child: Container(
-                            child: Text("日時"),
-                            alignment: Alignment.center,
-                            color: Colors.lightGreen,
-                          )
-                      ),
+                        child: Text("10:00~\n10:30"),
+                        alignment: Alignment.center,
+                      )),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("メインステージ"),
+                          child: Text("悠久太鼓愛好会\n鶴亀会"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("体育館"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Popular Music Club"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 3行目
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                        child: Text("10:30~\n11:00"),
+                        alignment: Alignment.center,
+                      )),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("合唱サークル"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 4行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:00~\n11:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 5行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:15~\n11:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Mexico"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("A講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 6行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:30~\n12:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 7行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:00~\n12:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Street Style"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("D講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 8行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:30~\n13:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 9行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:00~\n13:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 10行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:30~\n14:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Sri Lanka"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 12行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:00~\n14:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 11行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:30~\n15:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("吹奏楽部"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),

--- a/lib/pages/schedule_page_second_day_rainy.dart
+++ b/lib/pages/schedule_page_second_day_rainy.dart
@@ -1,0 +1,100 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class SchedulePageSecondDayRainy extends StatefulWidget {
+  @override
+  _SchedulePageSecondDayRainyState createState() => _SchedulePageSecondDayRainyState();
+}
+
+class _SchedulePageSecondDayRainyState extends State<SchedulePageSecondDayRainy> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      child: Container(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Column(
+            children: <Widget>[
+              Container(
+                child: Table(
+                  border: TableBorder.all(color: Colors.black),
+                  columnWidths: const<int, TableColumnWidth>{
+                    0: FlexColumnWidth(5),
+                    1: FlexColumnWidth(10),
+                    2: FlexColumnWidth(10),
+                    3: FlexColumnWidth(10),
+                    4: FlexColumnWidth(10),
+                    5: FlexColumnWidth(10),
+                  },
+                  defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                            color: Colors.lightGreen,
+                          )
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("体育館"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("武道場"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("A講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("D講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("マルチメディア"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/pages/schedule_page_second_day_rainy.dart
+++ b/lib/pages/schedule_page_second_day_rainy.dart
@@ -43,47 +43,927 @@ class _SchedulePageSecondDayRainyState extends State<SchedulePageSecondDayRainy>
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
+                    TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                              child: Container(
+                                child: Text("日時"),
+                                alignment: Alignment.center,
+                              )),
+                          TableCell(
+                            child: Container(
+                              child: Text("体育館"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("武道場"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("A講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("D講義室"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("マルチメディア"),
+                              alignment: Alignment.center,
+                            ),
+                          ),
+                        ]),
+
+                    // 2行目
                     TableRow(children: [
                       TableCell(
                           child: Container(
-                            child: Text("日時"),
+                            child: Text("10:00~\n10:30"),
                             alignment: Alignment.center,
-                            color: Colors.lightGreen,
-                          )
-                      ),
+                          )),
                       TableCell(
                         child: Container(
-                          child: Text("体育館"),
+                          child: Text("Mongolian\nstudent"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Popular Music Club"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 3行目
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                            child: Text("10:30~\n11:00"),
+                            alignment: Alignment.center,
+                          )),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 4行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:00~\n11:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("VYSAN"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("武道場"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("A講義室"),
+                          child: Text("ゲーム大会"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 5行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:30~\n12:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("D講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 7行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:00~\n12:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Street Style"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("マルチメディア"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 8行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:30~\n13:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 9行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:00~\n13:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 10行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:15~\n13:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("実践空手道部"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 11行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:30~\n14:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("NUT\nソフトウェア"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 12行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:00~\n14:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 13行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:15~\n14:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 14行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:30~\n15:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("カラオケ大会"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:00~\n15:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 16行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:30~\n16:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:00~\n16:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 16行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:30~\n17:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:00~\n17:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("学生番号抽選会"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:30~\n18:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("18:00~\n18:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),

--- a/lib/pages/schedule_page_second_day_sunny.dart
+++ b/lib/pages/schedule_page_second_day_sunny.dart
@@ -36,13 +36,13 @@ class _SchedulePageSecondDaySunnyState
                 child: Table(
                   border: TableBorder.all(color: Colors.black),
                   columnWidths: const <int, TableColumnWidth>{
-                    0: FlexColumnWidth(5),
-                    1: FlexColumnWidth(10),
-                    2: FlexColumnWidth(10),
-                    3: FlexColumnWidth(10),
-                    4: FlexColumnWidth(10),
-                    5: FlexColumnWidth(10),
-                    6: FlexColumnWidth(10),
+                    0: FlexColumnWidth(10),
+                    1: FlexColumnWidth(15),
+                    2: FlexColumnWidth(15),
+                    3: FlexColumnWidth(15),
+                    4: FlexColumnWidth(15),
+                    5: FlexColumnWidth(15),
+                    6: FlexColumnWidth(15),
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
@@ -53,48 +53,41 @@ class _SchedulePageSecondDaySunnyState
                               child: Container(
                             child: Text("日時"),
                             alignment: Alignment.center,
-                            color: Colors.lightGreen,
                           )),
                           TableCell(
                             child: Container(
                               child: Text("メインステージ"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                           TableCell(
                             child: Container(
                               child: Text("体育館"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                           TableCell(
                             child: Container(
                               child: Text("武道場"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                           TableCell(
                             child: Container(
                               child: Text("A講義室"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                           TableCell(
                             child: Container(
                               child: Text("D講義室"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                           TableCell(
                             child: Container(
                               child: Text("マルチメディア"),
                               alignment: Alignment.center,
-                              color: Colors.lightGreen,
                             ),
                           ),
                         ]),
@@ -245,15 +238,9 @@ class _SchedulePageSecondDaySunnyState
                         ),
                       ),
                       TableCell(
-                        child: Container(
-                          child: Text("ゲーム大会"),
-                          alignment: Alignment.center,
-                        ),
-                      ),
-                      TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text(""),
+                          child: Text("ゲーム大会"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
@@ -427,7 +414,21 @@ class _SchedulePageSecondDaySunnyState
                     TableRow(children: [
                       TableCell(
                         child: Container(
-                          child: Text("13:00~\n13:30"),
+                          child: Text("13:00~\n13:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                         ),
                       ),
@@ -453,9 +454,70 @@ class _SchedulePageSecondDaySunnyState
                           color: Colors.lightGreen,
                         ),
                       ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
                     ]),
 
                     // 10行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:15~\n13:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("実践空手道部"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 11行目
                     TableRow(children: [
                       TableCell(
                         child: Container(
@@ -466,14 +528,6 @@ class _SchedulePageSecondDaySunnyState
                       TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("Sri Lanka"),
-                          alignment: Alignment.center,
-                          color: Colors.lightGreen,
-                        ),
-                      ),
-                      TableCell(
-                        verticalAlignment: TableCellVerticalAlignment.fill,
-                        child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
                         ),
@@ -483,7 +537,37 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("NUT\nソフトウェア"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
@@ -492,7 +576,7 @@ class _SchedulePageSecondDaySunnyState
                     TableRow(children: [
                       TableCell(
                         child: Container(
-                          child: Text("14:00~\n14:30"),
+                          child: Text("14:00~\n14:15"),
                           alignment: Alignment.center,
                         ),
                       ),
@@ -518,9 +602,86 @@ class _SchedulePageSecondDaySunnyState
                           color: Colors.lightGreen,
                         ),
                       ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
                     ]),
 
-                    // 11行目
+                    // 13行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:15~\n14:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 14行目
                     TableRow(children: [
                       TableCell(
                         child: Container(
@@ -531,7 +692,7 @@ class _SchedulePageSecondDaySunnyState
                       TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("吹奏楽部"),
+                          child: Text("カラオケ大会"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
@@ -548,12 +709,34 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
 
-                    // 13行目
+                    // 15行目
                     TableRow(children: [
                       TableCell(
                         child: Container(
@@ -566,6 +749,21 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                       TableCell(
@@ -583,9 +781,16 @@ class _SchedulePageSecondDaySunnyState
                           color: Colors.lightGreen,
                         ),
                       ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
                     ]),
 
-                    // 14行目
+                    // 16行目
                     TableRow(children: [
                       TableCell(
                         child: Container(
@@ -612,12 +817,33 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
 
-                    // 15行目
+                    // 17行目
                     TableRow(children: [
                       TableCell(
                         child: Container(
@@ -644,7 +870,28 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
@@ -660,9 +907,15 @@ class _SchedulePageSecondDaySunnyState
                       TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("ヒーローショー"),
+                          child: Text(""),
                           alignment: Alignment.center,
-                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                       TableCell(
@@ -677,7 +930,21 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
@@ -693,23 +960,44 @@ class _SchedulePageSecondDaySunnyState
                       TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text(""),
-                          alignment: Alignment.center,
-                        ),
-                      ),
-                      TableCell(
-                        verticalAlignment: TableCellVerticalAlignment.fill,
-                        child: Container(
-                          child: Text(""),
-                          alignment: Alignment.center,
-                        ),
-                      ),
-                      TableCell(
-                        verticalAlignment: TableCellVerticalAlignment.fill,
-                        child: Container(
-                          child: Text(""),
+                          child: Text("学生番号抽選会"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),
@@ -727,12 +1015,50 @@ class _SchedulePageSecondDaySunnyState
                         child: Container(
                           child: Text(""),
                           alignment: Alignment.center,
+                          color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
                           child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("18:00~\n18:30"),
                           alignment: Alignment.center,
                         ),
                       ),
@@ -742,6 +1068,41 @@ class _SchedulePageSecondDaySunnyState
                           child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
                         ),
                       ),
                     ]),

--- a/lib/pages/schedule_page_second_day_sunny.dart
+++ b/lib/pages/schedule_page_second_day_sunny.dart
@@ -6,10 +6,12 @@ import 'package:http/http.dart' as http;
 
 class SchedulePageSecondDaySunny extends StatefulWidget {
   @override
-  _SchedulePageSecondDaySunnyState createState() => _SchedulePageSecondDaySunnyState();
+  _SchedulePageSecondDaySunnyState createState() =>
+      _SchedulePageSecondDaySunnyState();
 }
 
-class _SchedulePageSecondDaySunnyState extends State<SchedulePageSecondDaySunny> {
+class _SchedulePageSecondDaySunnyState
+    extends State<SchedulePageSecondDaySunny> {
 // notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
 
 //  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
@@ -33,7 +35,7 @@ class _SchedulePageSecondDaySunnyState extends State<SchedulePageSecondDaySunny>
               Container(
                 child: Table(
                   border: TableBorder.all(color: Colors.black),
-                  columnWidths: const<int, TableColumnWidth>{
+                  columnWidths: const <int, TableColumnWidth>{
                     0: FlexColumnWidth(5),
                     1: FlexColumnWidth(10),
                     2: FlexColumnWidth(10),
@@ -44,52 +46,700 @@ class _SchedulePageSecondDaySunnyState extends State<SchedulePageSecondDaySunny>
                   },
                   defaultVerticalAlignment: TableCellVerticalAlignment.middle,
                   children: [
-                    TableRow(children: [
-                      TableCell(
-                          child: Container(
+                    TableRow(
+                        decoration: BoxDecoration(color: Colors.teal),
+                        children: [
+                          TableCell(
+                              child: Container(
                             child: Text("日時"),
                             alignment: Alignment.center,
                             color: Colors.lightGreen,
-                          )
+                          )),
+                          TableCell(
+                            child: Container(
+                              child: Text("メインステージ"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("体育館"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("武道場"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("A講義室"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("D講義室"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                          TableCell(
+                            child: Container(
+                              child: Text("マルチメディア"),
+                              alignment: Alignment.center,
+                              color: Colors.lightGreen,
+                            ),
+                          ),
+                        ]),
+
+                    // 2行目
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                        child: Text("10:00~\n10:30"),
+                        alignment: Alignment.center,
+                      )),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("メインステージ"),
+                          child: Text("Mongolian\nstudent"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Popular Music Club"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 3行目
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                        child: Text("10:30~\n11:00"),
+                        alignment: Alignment.center,
+                      )),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                    ]),
+
+                    // 4行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:00~\n11:15"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("VYSAN"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("体育館"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
                         child: Container(
-                          child: Text("武道場"),
+                          child: Text("ゲーム大会"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 5行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("11:30~\n12:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("A講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 7行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:00~\n12:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Street Style"),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("D講義室"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),
                       ),
                       TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
                         child: Container(
-                          child: Text("マルチメディア"),
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 8行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("12:30~\n13:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 9行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:00~\n13:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 10行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("13:30~\n14:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("Sri Lanka"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 12行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:00~\n14:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 11行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("14:30~\n15:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("吹奏楽部"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 13行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:00~\n15:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 14行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("15:30~\n16:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:00~\n16:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 16行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("16:30~\n17:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text("ヒーローショー"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 15行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:00~\n17:30"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+
+                    // 17行目
+                    TableRow(children: [
+                      TableCell(
+                        child: Container(
+                          child: Text("17:30~\n18:00"),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
+                          alignment: Alignment.center,
+                        ),
+                      ),
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.fill,
+                        child: Container(
+                          child: Text(""),
                           alignment: Alignment.center,
                           color: Colors.lightGreen,
                         ),

--- a/lib/pages/schedule_page_second_day_sunny.dart
+++ b/lib/pages/schedule_page_second_day_sunny.dart
@@ -1,0 +1,107 @@
+import 'dart:developer';
+
+import 'package:seeft_mobile/configs/importer.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+
+class SchedulePageSecondDaySunny extends StatefulWidget {
+  @override
+  _SchedulePageSecondDaySunnyState createState() => _SchedulePageSecondDaySunnyState();
+}
+
+class _SchedulePageSecondDaySunnyState extends State<SchedulePageSecondDaySunny> {
+// notification関連をinitStateに書き出さなきゃいけないので書いてたけどutilとかに書いてもいいかもね
+
+//  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+//  NotificationDetails platformChannelSpecifics;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      child: Container(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Column(
+            children: <Widget>[
+              Container(
+                child: Table(
+                  border: TableBorder.all(color: Colors.black),
+                  columnWidths: const<int, TableColumnWidth>{
+                    0: FlexColumnWidth(5),
+                    1: FlexColumnWidth(10),
+                    2: FlexColumnWidth(10),
+                    3: FlexColumnWidth(10),
+                    4: FlexColumnWidth(10),
+                    5: FlexColumnWidth(10),
+                    6: FlexColumnWidth(10),
+                  },
+                  defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
+                    TableRow(children: [
+                      TableCell(
+                          child: Container(
+                            child: Text("日時"),
+                            alignment: Alignment.center,
+                            color: Colors.lightGreen,
+                          )
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("メインステージ"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("体育館"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("武道場"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("A講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("D講義室"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                      TableCell(
+                        child: Container(
+                          child: Text("マルチメディア"),
+                          alignment: Alignment.center,
+                          color: Colors.lightGreen,
+                        ),
+                      ),
+                    ]),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -86,7 +86,8 @@ class Api {
 
   // 準備日雨シフト
   Future getMyShiftPreparationDayRainy(id) async {
-    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/2';
+    // String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/2';
+    String url = constant.apiUrl + '/shifts/users/' + id + '/dates/1/weathers/1';
     try {
       return await get(url);
     } catch (err) {
@@ -206,20 +207,10 @@ class Api {
 
   // Get Shift Detail
   Future shiftDetail(workId, userId, date, weather, time) async {
-    logger.w(time);
-    var url = constant.apiUrl +
-        "/work/" +
-        workId.toString() +
-        "/" +
-        userId.toString() +
-        "/" +
-        date +
-        "/" +
-        weather +
-        "/" +
-        time;
-    logger.w(url);
+    // logger.w(time);
+    var url = constant.apiUrl + "/tasks/shifts/" + workId.toString();
     try {
+      logger.i(url);
       var res = await get(url);
       logger.i(res);
       return await get(url);

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -36,8 +36,8 @@ class ApplicationDrawer {
           title: Text("タイムスケジュール"),
           leading: Icon(Icons.schedule),
           onTap: () => {
-            Navigator.pushNamedAndRemoveUntil(
-                context, '/schedule_page', (Route<dynamic> route) => false)
+            // Navigator.pushNamedAndRemoveUntil(
+            //     context, '/schedule_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(

--- a/lib/widgets/drawer.dart
+++ b/lib/widgets/drawer.dart
@@ -36,8 +36,8 @@ class ApplicationDrawer {
           title: Text("タイムスケジュール"),
           leading: Icon(Icons.schedule),
           onTap: () => {
-            // Navigator.pushNamedAndRemoveUntil(
-            //     context, '/schedule_page', (Route<dynamic> route) => false)
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/schedule_page', (Route<dynamic> route) => false)
           },
         ),
         ListTile(

--- a/lib/widgets/shift_dialog.dart
+++ b/lib/widgets/shift_dialog.dart
@@ -3,6 +3,7 @@ import 'package:seeft_mobile/configs/importer.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 getShiftDetail(workId, userId, date, weather, time) async {
+  // 本当は引数はworkIdだけでいいが、今後ほかの要素を使うことも考えてそのままに
   try {
     logger.w(workId);
     var res = await api.shiftDetail(workId, userId, date, weather, time);
@@ -22,11 +23,11 @@ openShiftDialog(
     BuildContext context, workId, userId, date, weather, time) async {
   var res = await getShiftDetail(workId, userId, date, weather, time);
   logger.i(res);
-  var resName = res["Name"];
-  var resURL = res["URL"];
-  var resUsers = res["Users"];
-  var resPlace = res["Place"];
-  var resPresident = res["President"];
+  var resName = res["task"];
+  var resURL = res["url"];
+  var resUsers = res["users"];
+  var resPlace = res["place"];
+  var resPresident = res["superviser"];
   var resPresidentTel = res["TEL"];
   showDialog(
     context: context,
@@ -58,16 +59,17 @@ openShiftDialog(
                     title: Text("集合場所"),
                     subtitle: Text(resPlace),
                   ),
-                  ListTile(
-                    leading: Icon(Icons.supervisor_account_outlined),
-                    title: Text("代表者"),
-                    subtitle: Text(resPresident),
-                  ),
-                  ListTile(
-                    leading: Icon(Icons.phone),
-                    title: Text("緊急時連絡先"),
-                    subtitle: Text(resPresidentTel),
-                  ),
+                  // 今回はいらないので一時的にコメントアウト
+                  // ListTile(
+                  //   leading: Icon(Icons.supervisor_account_outlined),
+                  //   title: Text("代表者"),
+                  //   subtitle: Text(resPresident),
+                  // ),
+                  // ListTile(
+                  //   leading: Icon(Icons.phone),
+                  //   title: Text("緊急時連絡先"),
+                  //   subtitle: Text(resPresidentTel),
+                  // ),
                   ListTile(
                     leading: Icon(Icons.group),
                     title: Text("メンバー"),

--- a/lib/widgets/table.dart
+++ b/lib/widgets/table.dart
@@ -69,8 +69,8 @@ class ShiftTable {
                       child: InkWell(
                         splashColor: Colors.orangeAccent,
                         onTap: () async {
-                          if (shifts[index]["task"] != "") {
-                            logger.i(shifts[index]["task"]);
+                          if (shifts[index]["task"]["task"] != "") {
+                            logger.i(shifts[index]["task"]["task"]);
                             await openShiftDialog(
                                 context,
                                 shifts[index]["task"]["id"],


### PR DESCRIPTION
シフトをタップすると、そのシフトの詳細をダイアログで開くようにしました。
注意として、seedデータが準備日の晴天時しかないため、全シフトページでとりあえずそのAPIを叩いています。
本番環境の際はapi.dartのURLを適宜コメントアウトして、実際のシフトを読み込むようにしてください。